### PR TITLE
Fix Utils.durationString duration string generation bugs

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -520,8 +520,8 @@ class Util {
 
         const parsed = items.filter((x) => required.includes(x)).map((m) => (data[m] > 0 ? data[m] : ""));
         const final = parsed
-            .filter((x) => !!x)
-            .map((x) => x.toString().padStart(2, "0"))
+            .slice(parsed.findIndex((x) => !!x))
+            .map((x, i) => i == 0 ? x.toString() : x.toString().padStart(2, "0"))
             .join(":");
         return final.length <= 3 ? `0:${final.padStart(2, "0") || 0}` : final;
     }


### PR DESCRIPTION
`Utils.durationString` method generates wrong duration string by skipping required zeroes (e.g. skipping `00` minutes part when there's more than 0 hours) and adding zero at the start of the string when it's not necessary (e.g. `02:30` instead of `2:30`).

Wrong result examples:
1. When `data`: `{"days":0,"hours":3,"minutes":0,"seconds":59}`
Expected: `3:00:59`, actual: `03:59`.
2. When `data`: `{"days":0,"hours":0,"minutes":5,"seconds":0}`
Expected: `5:00`, actual: `0:05`.
3. When `data`: `{"days":0,"hours":0,"minutes":2,"seconds":48}`
Expected: `2:48`, actual: `02:48`.