### PR TITLE
fix(Util): Video likes count is not guaranteed

### DIFF
--- a/src/Util.ts
+++ b/src/Util.ts
@@ -408,7 +408,7 @@ class Util {
             },
             uploadedAt: info.dateText.simpleText,
             ratings: {
-                likes: this.getInfoLikesCount(info),
+                likes: this.getInfoLikesCount(info) || 0,
                 dislikes: 0
             },
             videos: Util.getNext(nextData ?? {}) || []
@@ -422,7 +422,7 @@ class Util {
         const button = buttons.find((button) => button.toggleButtonRenderer?.defaultIcon.iconType === "LIKE");
         if (!button) return 0;
 
-        return parseInt(button.toggleButtonRenderer.defaultText.accessibility.accessibilityData.label.split(" ")[0].replace(/,/g, ""));
+        return parseInt(button.toggleButtonRenderer.defaultText.accessibility?.accessibilityData.label.split(" ")[0].replace(/,/g, ""));
     }
 
     static getNext(body: any, home = false): Video[] {


### PR DESCRIPTION
`YouTube.getVideo("Some_Video_URL")` returns an error:
`Error: Cannot read properties of undefined (reading 'accessibilityData')`
for videos that don't have their ratings visible. An example of a video that doesn't show it's ratings is https://www.youtube.com/watch?v=LL998ajnjN4 and has been used in the testing of this fix. An additional video that doesn't have ratings enabled (currently at least) is https://www.youtube.com/watch?v=aKSxbt-O6TA and can also be used for testing.

This fix makes the accessibility property in getInfoLikesCount() optional for when a video has their number of likes hidden and there is no accessibility property available.

Additionally, this adds an || OR operator to a video's like ratings that returns 0 if getInfoLikesCount(info) returns NaN after being unable to return the likes count of a video.